### PR TITLE
Adding AppEvent entity to the database

### DIFF
--- a/src/ApplicationTracker.Data/Configurations/AppEventConfiguration.cs
+++ b/src/ApplicationTracker.Data/Configurations/AppEventConfiguration.cs
@@ -1,0 +1,42 @@
+﻿using ApplicationTracker.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ApplicationTracker.Data.Configurations
+{
+    public class AppEventConfiguration : IEntityTypeConfiguration<AppEvent>
+    {
+        public void Configure(EntityTypeBuilder<AppEvent> builder)
+        {
+            builder.HasKey(x => x.Id);
+            
+            builder.HasIndex(x => x.ApplicationId);
+
+            builder.Property(x => x.Id)
+                .ValueGeneratedOnAdd();
+
+            builder.Property(x => x.EventDate)
+                .IsRequired();
+
+            builder.Property(x => x.ContactMethod)
+                .IsRequired()
+                .HasConversion<string>();
+
+            builder.Property(x => x.EventType)
+                .IsRequired()
+                .HasConversion<string>();
+
+            builder.HasOne(x => x.Application)
+                .WithMany(a => a.AppEvents)
+                .HasForeignKey(x => x.ApplicationId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+        }
+    }
+}

--- a/src/ApplicationTracker.Data/Configurations/ApplicationConfiguration.cs
+++ b/src/ApplicationTracker.Data/Configurations/ApplicationConfiguration.cs
@@ -36,6 +36,11 @@ namespace ApplicationTracker.Data.Configurations
                    .HasForeignKey(a => a.SourceId)
                    .OnDelete(DeleteBehavior.Restrict);
 
+            builder.HasMany(a => a.AppEvents)
+                   .WithOne(e => e.Application)
+                   .HasForeignKey(e => e.ApplicationId)
+                   .OnDelete(DeleteBehavior.Restrict);
+
             // Other Properties
             builder.Property(a => a.ApplicationDate)
                    .IsRequired();

--- a/src/ApplicationTracker.Data/Dtos/ApplicationDto.cs
+++ b/src/ApplicationTracker.Data/Dtos/ApplicationDto.cs
@@ -1,4 +1,6 @@
-﻿namespace ApplicationTracker.Data.Dtos
+﻿using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace ApplicationTracker.Data.Dtos
 {
 #pragma warning disable CS8618
     public class ApplicationDto
@@ -11,6 +13,7 @@
         public WorkEnvironmentDto WorkEnvironment { get; set; }
         public string? City { get; set; }
         public string? State { get; set; }
+        public bool IsRejected { get; set; } = true;
     }
 #pragma warning restore CS8618
 }

--- a/src/ApplicationTracker.Data/Entities/AppEvent.cs
+++ b/src/ApplicationTracker.Data/Entities/AppEvent.cs
@@ -1,0 +1,26 @@
+﻿using ApplicationTracker.Data.Enum;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ApplicationTracker.Data.Entities
+{
+#pragma warning disable CS8618
+    public class AppEvent 
+    {
+        public int Id { get; set; }
+        public int ApplicationId { get; set; }
+        public Application Application { get; set; }
+        public DateTime EventDate { get; set; }
+        [StringLength(50)]
+        public ContactMethod ContactMethod { get; set; }
+        [StringLength(50)]
+        public EventType EventType { get; set; }
+        [StringLength(1000)]
+        public string Description { get; set; }
+    }
+#pragma warning restore CS8618
+}

--- a/src/ApplicationTracker.Data/Entities/Application.cs
+++ b/src/ApplicationTracker.Data/Entities/Application.cs
@@ -19,6 +19,7 @@ namespace ApplicationTracker.Data.Entities
         public string? City { get; set; }
         [StringLength(2)]
         public string? State { get; set; }
+        public List<AppEvent> AppEvents { get; set; } = new List<AppEvent>();
     }
 #pragma warning restore CS8618
 }

--- a/src/ApplicationTracker.Data/Enum/ContactMethod.cs
+++ b/src/ApplicationTracker.Data/Enum/ContactMethod.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ApplicationTracker.Data.Enum
+{
+    public enum ContactMethod
+    {
+        Call = 1,
+        Email = 2,
+        SMS = 3,
+    }
+}

--- a/src/ApplicationTracker.Data/Enum/EventType.cs
+++ b/src/ApplicationTracker.Data/Enum/EventType.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ApplicationTracker.Data.Enum
+{
+    public enum EventType
+    {
+        Interview = 1,
+        Rejection = 2,
+    }
+}

--- a/src/ApplicationTracker.Data/Migrations/20250214234325_AddAppEvents.Designer.cs
+++ b/src/ApplicationTracker.Data/Migrations/20250214234325_AddAppEvents.Designer.cs
@@ -4,6 +4,7 @@ using ApplicationTracker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ApplicationTracker.Data.Migrations
 {
     [DbContext(typeof(TrackerDbContext))]
-    partial class TrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250214234325_AddAppEvents")]
+    partial class AddAppEvents
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ApplicationTracker.Data/Migrations/20250214234325_AddAppEvents.cs
+++ b/src/ApplicationTracker.Data/Migrations/20250214234325_AddAppEvents.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ApplicationTracker.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAppEvents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AppEvents",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ApplicationId = table.Column<int>(type: "int", nullable: false),
+                    EventDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ContactMethod = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    EventType = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(1000)", maxLength: 1000, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AppEvents", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AppEvents_Applications_ApplicationId",
+                        column: x => x.ApplicationId,
+                        principalTable: "Applications",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AppEvents_ApplicationId",
+                table: "AppEvents",
+                column: "ApplicationId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AppEvents");
+        }
+    }
+}

--- a/src/ApplicationTracker.Data/TrackerDbContext.cs
+++ b/src/ApplicationTracker.Data/TrackerDbContext.cs
@@ -13,11 +13,11 @@ namespace ApplicationTracker.Data
         public DbSet<JobTitle> JobTitles { get; set; }
         public DbSet<Organization> Organizations { get; set; }
         public DbSet<Source> Sources { get; set; }
+        public DbSet<AppEvent> AppEvents { get; set; }
 
         public TrackerDbContext(DbContextOptions<TrackerDbContext> options)
             : base(options)
         { }
-
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/src/UnitTests/ApplicationTracker.ImportCli.Test/CommandLine/OptionsTests.cs
+++ b/src/UnitTests/ApplicationTracker.ImportCli.Test/CommandLine/OptionsTests.cs
@@ -33,7 +33,7 @@ namespace ApplicationTracker.ImportCli.Test.CommandLine
         [Test]
         public void ValidateRequired_ShouldReturnFalse_WhenFilePathIsMissing()
         {
-            // Setup
+            // Arrange
             var options = new Options { FilePath = string.Empty };
 
             // Act
@@ -50,7 +50,7 @@ namespace ApplicationTracker.ImportCli.Test.CommandLine
         [Test]
         public void ValidateRequired_ShouldReturnTrue_WhenFilePathIsProvided()
         {
-            // Setup
+            // Arrange
             var options = new Options { FilePath = "somefile.txt" };
 
             // Act 
@@ -63,7 +63,7 @@ namespace ApplicationTracker.ImportCli.Test.CommandLine
         [Test]
         public void ValidateFilePath_ShouldReturnFalse_WhenFilePathIsEmpty()
         {
-            // Setup
+            // Arrange
             var options = new Options { FilePath = string.Empty };
 
             // Act
@@ -80,7 +80,7 @@ namespace ApplicationTracker.ImportCli.Test.CommandLine
         [Test]
         public void ValidateFilePath_ShouldReturnFalse_WhenFileDoesNotExist()
         {
-            // Setup
+            // Arrange
             var options = new Options { FilePath = "nonexistentfile.txt" };
 
             // Act
@@ -97,7 +97,7 @@ namespace ApplicationTracker.ImportCli.Test.CommandLine
         [Test]
         public void ValidateFilePath_ShouldReturnTrue_WhenFileExists()
         {
-            // Setup 
+            // Arrange 
             var options = new Options { FilePath = ValidFilePath };
 
             // Act 

--- a/src/UnitTests/ApplicationTracker.ImportCli.Test/ProgramTests.cs
+++ b/src/UnitTests/ApplicationTracker.ImportCli.Test/ProgramTests.cs
@@ -30,7 +30,7 @@
         [Test]
         public void ProcessArguments_ShouldReturnError_WhenFileDoesNotExist()
         {
-            // Setup
+            // Arrange
             var args = new string[] { "-f", "nonexistent.txt" };
             
             // Act 
@@ -46,7 +46,7 @@
         [Test]
         public void ProcessArguments_ReturnsError_WhenNoArgumentsProvided()
         {
-            // Setup
+            // Arrange
             var args = new string[0];
 
             // Act

--- a/src/UnitTests/ApplicationTracker.Services.Tests/ApplicationServiceTests.cs
+++ b/src/UnitTests/ApplicationTracker.Services.Tests/ApplicationServiceTests.cs
@@ -16,6 +16,7 @@ namespace ApplicationTracker.Services.Tests
         [SetUp]
         public void SetUp()
         {
+            // add reject app event to context helper then test for reject 
             _context = ContextHelper.GetInMemoryContext<Application>(rows: 5);
             _logger = new LoggerFactory().CreateLogger<ApplicationService>();
             _service = new ApplicationService(_context, _logger);
@@ -48,6 +49,9 @@ namespace ApplicationTracker.Services.Tests
                 Assert.That(result?.Source.Id, Is.EqualTo(1));
             });
         }
+
+        // Add test for IsActive 
+        
 
         [Test]
         public async Task PostAsync_ShouldAddNewApplication()

--- a/src/UnitTests/ApplicationTracker.Services.Tests/ApplicationServiceTests.cs
+++ b/src/UnitTests/ApplicationTracker.Services.Tests/ApplicationServiceTests.cs
@@ -50,13 +50,41 @@ namespace ApplicationTracker.Services.Tests
             });
         }
 
-        // Add test for IsActive 
-        
+        [Test]
+        public async Task GetByIdAsync_ShouldReturneApplicationWithIsRejectedTrue_WhenApplicationIsRejected()
+        {
+            // Arrange
+            ContextHelper.AddRejectionEvent(_context, 1);
+            
+            // Act
+            var result = await _service.GetByIdAsync(1);
+            
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.Not.Null);
+                Assert.That(result?.IsRejected, Is.True);
+            });
+        }
+
+        [Test]
+        public async Task GetByIdAsync_ShouldReturneApplicationWithIsRejectedFalse_WhenApplicationIsNotRejected()
+        {
+            // Act
+            var result = await _service.GetByIdAsync(1);
+            
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.Not.Null);
+                Assert.That(result?.IsRejected, Is.False);
+            });
+        }
 
         [Test]
         public async Task PostAsync_ShouldAddNewApplication()
         {
-            // Setup
+            // Arrange
             var applicationDto = new ApplicationDto
             {
                 ApplicationDate = DateOnly.FromDateTime(DateTime.Now),
@@ -124,7 +152,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task ExistsAsync_ShouldReturnFalse_WhenApplicationWithDtoDoesNotExist()
         {
-            // Setup
+            // Arrange
             var applicationDto = new ApplicationDto
             {
                 ApplicationDate = DateOnly.FromDateTime(DateTime.Now),
@@ -144,7 +172,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task UpdateAsync_ShouldThrowException_WhenApplicationIdIsNull()
         {
-            // Setup
+            // Arrange
             var applicationDto = new ApplicationDto { Id = null };
 
             // Act 
@@ -172,7 +200,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task UpdateAsync_ShouldThrowException_WhenSourceIdIsNull()
         {
-            // Setup
+            // Arrange
             var applicationDto = new ApplicationDto
             {
                 Id = 1,
@@ -204,7 +232,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task UpdateAsync_ShouldThrowKeyNotFoundException_WhenApplicationNotFound()
         {
-            // Setup
+            // Arrange
             var applicationDto = new ApplicationDto
             {
                 Id = 999, // non-existent Id
@@ -239,7 +267,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task UpdateAsync_ShouldUpdateApplication_WhenValidApplicationExists()
         {
-            // Setup
+            // Arrange
             var existingApplication = _context.Applications.First(); // Get an existing application
             var applicationDto = new ApplicationDto
             {

--- a/src/UnitTests/ApplicationTracker.Services.Tests/Factory/ServiceFactoryTests.cs
+++ b/src/UnitTests/ApplicationTracker.Services.Tests/Factory/ServiceFactoryTests.cs
@@ -23,7 +23,7 @@ namespace ApplicationTracker.Services.Tests.Factory
         [Test]
         public void GetService_ReturnsService_WhenServiceExists()
         {
-            // Setup
+            // Arrange
             var mockJobTitleService = new Mock<IService<JobTitleDto>>();
             _mockServiceProvider
                 .Setup(sp => sp.GetService(typeof(JobTitleService)))
@@ -44,7 +44,7 @@ namespace ApplicationTracker.Services.Tests.Factory
         [Test]
         public void GetService_ThrowsInvalidOperationException_WhenServiceExistsInMapButNotInProvider()
         {
-            // Setup
+            // Arrange
             _mockServiceProvider
                 .Setup(sp => sp.GetService(typeof(JobTitleService)))
                 .Returns(default(IService<JobTitleDto>));

--- a/src/UnitTests/ApplicationTracker.Services.Tests/JobTitlesServiceTests.cs
+++ b/src/UnitTests/ApplicationTracker.Services.Tests/JobTitlesServiceTests.cs
@@ -25,7 +25,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task GetAllAsync_ReturnsAllJobTitles()
         {
-            // Setup
+            // Arrange
             var testId = 1;
             var expected = $"Test {typeof(JobTitle).Name} {testId}";
 
@@ -44,7 +44,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task GetByIdAsync_ReturnsNull_WhenIdDoesNotExist()
         {
-            // Setup 
+            // Arrange 
             var testId = 99;
 
             // Act
@@ -57,7 +57,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task ExistsAsync_ReturnsTrue_WhenIdExists()
         {
-            // Setup
+            // Arrange
             var testId = 1;
 
             // Act
@@ -70,7 +70,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task ExistsAsync_ReturnsFalse_WhenIdDoesNotExist()
         {
-            // Setup 
+            // Arrange 
             var testId = 99;
 
             // Act

--- a/src/UnitTests/ApplicationTracker.Services.Tests/OrganizationServiceTests.cs
+++ b/src/UnitTests/ApplicationTracker.Services.Tests/OrganizationServiceTests.cs
@@ -26,7 +26,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task GetAllAsync_ReturnsAllOrganizations()
         {
-            // Setup
+            // Arrange
             var testId = 1;
             var expected = $"Test {typeof(Organization).Name} {testId}";
 
@@ -45,7 +45,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task GetByIdAsync_ReturnsNull_WhenIdDoesNotExist()
         {
-            // Setup 
+            // Arrange 
             var testId = 99;
 
             // Act
@@ -58,7 +58,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task ExistsAsync_ReturnsTrue_WhenIdExists()
         {
-            // Setup
+            // Arrange
             var testId = 1;
 
             // Act
@@ -71,7 +71,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task ExistsAsync_ReturnsFalse_WhenIdDoesNotExist()
         {
-            // Setup 
+            // Arrange 
             var testId = 99;
 
             // Act

--- a/src/UnitTests/ApplicationTracker.Services.Tests/SourcesServiceTests.cs
+++ b/src/UnitTests/ApplicationTracker.Services.Tests/SourcesServiceTests.cs
@@ -25,7 +25,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task GetAllAsync_ReturnsAllSources()
         {
-            // Setup
+            // Arrange
             var testId = 1;
             var expected = $"Test {typeof(Source).Name} {testId}";
 
@@ -45,7 +45,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task GetByIdAsync_ReturnsNull_WhenIdDoesNotExist()
         {
-            // Setup 
+            // Arrange 
             var testId = 99;
 
             // Act
@@ -58,7 +58,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task ExistsAsync_ReturnsTrue_WhenIdExists()
         {
-            // Setup
+            // Arrange
             var testId = 1;
 
             // Act
@@ -71,7 +71,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task ExistsAsync_ReturnsFalse_WhenIdDoesNotExist()
         {
-            // Setup 
+            // Arrange 
             var testId = 99;
 
             // Act

--- a/src/UnitTests/ApplicationTracker.Services.Tests/WorkEnvironmentServiceTests.cs
+++ b/src/UnitTests/ApplicationTracker.Services.Tests/WorkEnvironmentServiceTests.cs
@@ -25,7 +25,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task GetAllAsync_ReturnsAllWorkEnvironments()
         {
-            // Setup
+            // Arrange
             var testId = 1;
             var expected = $"Test {typeof(WorkEnvironment).Name} {testId}";
 
@@ -45,7 +45,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task GetByIdAsync_ReturnsNull_WhenIdDoesNotExist()
         {
-            // Setup 
+            // Arrange 
             var testId = 99;
 
             // Act
@@ -58,7 +58,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task ExistsAsync_ReturnsTrue_WhenIdExists()
         {
-            // Setup
+            // Arrange
             var testId = 1;
 
             // Act
@@ -71,7 +71,7 @@ namespace ApplicationTracker.Services.Tests
         [Test]
         public async Task ExistsAsync_ReturnsFalse_WhenIdDoesNotExist()
         {
-            // Setup 
+            // Arrange 
             var testId = 99;
 
             // Act

--- a/src/UnitTests/ApplicationTracker.TestUtilities/Helpers/ContextHelper.cs
+++ b/src/UnitTests/ApplicationTracker.TestUtilities/Helpers/ContextHelper.cs
@@ -1,5 +1,6 @@
 ﻿using ApplicationTracker.Data;
 using ApplicationTracker.Data.Entities;
+using ApplicationTracker.Data.Enum;
 using Microsoft.EntityFrameworkCore;
 using System.Diagnostics.CodeAnalysis;
 
@@ -57,6 +58,23 @@ namespace ApplicationTracker.TestUtilities.Helpers
             });
 
             context.Applications.AddRange(applications);
+            context.SaveChanges();
+        }
+
+        public static void AddRejectionEvent(TrackerDbContext context, int applicationId)
+        {
+            var application = context.Applications.Find(applicationId) ?? 
+                throw new InvalidOperationException("Application not found");
+            
+            var appEvent = new AppEvent
+            {
+                ApplicationId = applicationId,
+                EventDate = DateTime.Now,
+                EventType = EventType.Rejection,
+                Description = "Test Rejection"
+            };
+            
+            context.AppEvents.Add(appEvent);
             context.SaveChanges();
         }
 

--- a/src/UnitTests/ApplicationTracker.Tests/Common/ErrorHelperTests.cs
+++ b/src/UnitTests/ApplicationTracker.Tests/Common/ErrorHelperTests.cs
@@ -15,7 +15,7 @@ namespace ApplicationTracker.Tests.Common
         [Test]
         public void InternalServerError_ReturnsExpectedObjectResult()
         {
-            // Setup
+            // Arrange
             var message = "Internal server error occurred";
             var detail = "An unexpected error happened.";
 
@@ -40,7 +40,7 @@ namespace ApplicationTracker.Tests.Common
         [Test]
         public void NotFound_ReturnsExpectedNotFoundObjectResult()
         {
-            // Setup
+            // Arrange
             var message = "Resource not found";
             var detail = "The requested resource could not be found.";
 
@@ -64,7 +64,7 @@ namespace ApplicationTracker.Tests.Common
         [Test]
         public void BadRequest_ReturnsExpectedBadRequestObjectResult()
         {
-            // Setup
+            // Arrange
             var message = "Invalid request";
             var detail = "The request parameters were invalid.";
 
@@ -88,7 +88,7 @@ namespace ApplicationTracker.Tests.Common
         [Test]
         public void ValidateParameters_ThrowsArgumentException_WhenMessageIsNullOrEmpty()
         {
-            // Setup
+            // Arrange
             var detail = "Detail message";
 
             // Act & Assert
@@ -99,7 +99,7 @@ namespace ApplicationTracker.Tests.Common
         [Test]
         public void ValidateParameters_ThrowsArgumentException_WhenDetailIsNullOrEmpty()
         {
-            // Setup
+            // Arrange
             var message = "Error message";
 
             // Act & Assert

--- a/src/UnitTests/ApplicationTracker.Tests/Common/ServiceCallHandlerTests.cs
+++ b/src/UnitTests/ApplicationTracker.Tests/Common/ServiceCallHandlerTests.cs
@@ -28,7 +28,7 @@ namespace ApplicationTracker.Tests.Common
         [Test]
         public async Task HandleServiceCall_ReturnsResult_WhenActionExecutesSuccessfully()
         {
-            // Setup
+            // Arrange
             _mockServiceFactory
                 .Setup(factory => factory.GetService<TestService>())
                 .Returns(_mockService.Object);
@@ -50,7 +50,7 @@ namespace ApplicationTracker.Tests.Common
         [Test]
         public async Task HandleServiceCall_ReturnsInternalServerError_WhenActionReturnsNull()
         {
-            // Setup
+            // Arrange
             _mockServiceFactory
                 .Setup(factory => factory.GetService<TestService>())
                 .Returns(_mockService.Object);
@@ -82,7 +82,7 @@ namespace ApplicationTracker.Tests.Common
         [Test]
         public async Task HandleServiceCall_ReturnsInternalServerError_WhenServiceFactoryThrowsInvalidOperationException()
         {
-            // Setup
+            // Arrange
             _mockServiceFactory
                 .Setup(factory => factory.GetService<TestService>())
                 .Throws(new InvalidOperationException("Service not found"));
@@ -114,7 +114,7 @@ namespace ApplicationTracker.Tests.Common
         [Test]
         public async Task HandleServiceCall_ReturnsInternalServerError_WhenServiceFactoryThrowsArgumentException()
         {
-            // Setup
+            // Arrange
             _mockServiceFactory
                 .Setup(factory => factory.GetService<TestService>())
                 .Throws(new ArgumentException("Service not registered"));
@@ -145,7 +145,7 @@ namespace ApplicationTracker.Tests.Common
         [Test]
         public async Task HandleServiceCall_ReturnsInternalServerError_WhenUnhandledExceptionOccurs()
         {
-            // Setup
+            // Arrange
             _mockServiceFactory
                 .Setup(factory => factory.GetService<TestService>())
                 .Returns(_mockService.Object);

--- a/src/UnitTests/ApplicationTracker.Tests/Common/ValidationHelperTests.cs
+++ b/src/UnitTests/ApplicationTracker.Tests/Common/ValidationHelperTests.cs
@@ -9,7 +9,7 @@ namespace ApplicationTracker.Tests.Common
         [Test]
         public void IsValidId_ReturnsTrue_WhenIdIsGreaterThanZero()
         {
-            // Setup
+            // Arrange
             int id = 5;
 
             // Act
@@ -26,7 +26,7 @@ namespace ApplicationTracker.Tests.Common
         [Test]
         public void IsValidId_ReturnsFalse_WhenIdIsZeroOrLess()
         {
-            // Setup
+            // Arrange
             int id = 0;
 
             // Act

--- a/src/UnitTests/ApplicationTracker.Tests/Controllers/ApplicationsControllerTests.cs
+++ b/src/UnitTests/ApplicationTracker.Tests/Controllers/ApplicationsControllerTests.cs
@@ -26,7 +26,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task GetAllApplications_ReturnsOkResult_WhenApplicationsExist()
         {
-            // Setup
+            // Arrange
             var applications = new List<ApplicationDto>
             {
                 new ApplicationDto { Id = 1, ApplicationDate = DateOnly.FromDateTime(DateTime.Now) },
@@ -51,7 +51,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task GetAllApplications_ReturnsNotFound_WhenNoApplicationsExist()
         {
-            // Setup
+            // Arrange
             _mockService.Setup(s => s.GetAllAsync()).ReturnsAsync(new List<ApplicationDto>());
 
             // Act
@@ -73,7 +73,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task GetApplication_ReturnsOkResult_WhenApplicationExists()
         {
-            // Setup
+            // Arrange
             var application = new ApplicationDto { Id = 1, ApplicationDate = DateOnly.FromDateTime(DateTime.Now) };
             _mockService.Setup(s => s.ExistsAsync(1)).ReturnsAsync(true);
             _mockService.Setup(s => s.GetByIdAsync(1)).ReturnsAsync(application);
@@ -94,7 +94,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task GetApplication_ReturnsNotFound_WhenApplicationDoesNotExist()
         {
-            // Setup
+            // Arrange
             _mockService.Setup(s => s.ExistsAsync(1)).ReturnsAsync(false);
 
             // Act
@@ -116,7 +116,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task PostNewApplication_ReturnsOkResult_WhenApplicationIsValid()
         {
-            // Setup
+            // Arrange
             var application = new ApplicationDto
             {
                 ApplicationDate = DateOnly.FromDateTime(DateTime.Now),
@@ -144,7 +144,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task PostNewApplication_Returns_Conflict_WhenApplicationAlreadyExists()
         {
-            // Setup
+            // Arrange
             var application = new ApplicationDto
             {
                 ApplicationDate = DateOnly.FromDateTime(DateTime.Now),
@@ -166,7 +166,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task PostNewApplication_ReturnsBadRequest_WhenApplicationIsInvalid()
         {
-            // Setup
+            // Arrange
             _mockService.Setup(s => s.PostAsync(It.IsAny<ApplicationDto>()))
                         .ThrowsAsync(new ArgumentException("Invalid application"));
 
@@ -194,7 +194,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task PostNewApplication_ReturnsInternalServerError_OnException()
         {
-            // Setup
+            // Arrange
             var application = new ApplicationDto 
             { 
                 ApplicationDate = DateOnly.FromDateTime(DateTime.Now),
@@ -247,7 +247,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task UpdateApplication_IdMismatch_ReturnsBadRequest()
         {
-            // Setup
+            // Arrange
             var application = new ApplicationDto { Id = 2 };
 
             // Act
@@ -270,7 +270,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task UpdateApplication_InvalidApplication_ReturnsBadRequest()
         {
-            // Setup
+            // Arrange
             var application = new ApplicationDto { Id = 1 };
 
 
@@ -293,7 +293,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task UpdateApplication_ApplicationNotFound_ReturnsNotFound()
         {
-            // Setup
+            // Arrange
             var application = new ApplicationDto 
             { 
                 Id = 1, 
@@ -322,7 +322,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task UpdateApplication_ValidRequest_ReturnsOkWithUpdatedApplication()
         {
-            // Setup
+            // Arrange
             var application = new ApplicationDto
             {
                 Id = 1,
@@ -360,7 +360,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task UpdateApplication_ThrowsException_ReturnsInternalServerError()
         {
-            // Setup
+            // Arrange
             var application = new ApplicationDto
             {
                 Id = 1,

--- a/src/UnitTests/ApplicationTracker.Tests/Controllers/JobTitlesControllerTests.cs
+++ b/src/UnitTests/ApplicationTracker.Tests/Controllers/JobTitlesControllerTests.cs
@@ -49,7 +49,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task GetJobTitles_ReturnsOk_WhenJobTitlesExists()
         {
-            // Setup
+            // Arrange
             _mockService
                 .Setup(service => service.GetAllAsync())
                 .ReturnsAsync(_jobTitles);
@@ -75,7 +75,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task GetJobTitles_ReturnsNotFound_WhenNoJobTitlesExists()
         {
-            // Setup
+            // Arrange
             _mockService
                 .Setup(service => service.GetAllAsync())
                 .ReturnsAsync(new List<JobTitleDto>());
@@ -100,7 +100,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task GetJobTitle_ReturnsOk_WhenJobTitleExists()
         {
-            // Setup
+            // Arrange
             var testId = 1;
 
             _mockService
@@ -132,7 +132,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task GetJobTitle_ReturnsNotFound_WhenJobTitleDoesNotExist()
         {
-            // Setup
+            // Arrange
             var testId = 99;
             _mockService
                 .Setup(service => service.ExistsAsync(testId))

--- a/src/UnitTests/ApplicationTracker.Tests/Controllers/OrganizationsControllerTests.cs
+++ b/src/UnitTests/ApplicationTracker.Tests/Controllers/OrganizationsControllerTests.cs
@@ -48,7 +48,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task GetOrganizations_ReturnsOk_WhenOrganizationsExists()
         {
-            // Setup 
+            // Arrange 
             _mockService
                 .Setup(service => service.GetAllAsync())
                 .ReturnsAsync(_organizations);
@@ -74,7 +74,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task GetOrganizations_ReturnsNotFound_WhenNoOrganizationsExists()
         {
-            // Setup
+            // Arrange
             _mockService
                 .Setup(service => service.GetAllAsync())
                 .ReturnsAsync(new List<OrganizationDto>());
@@ -99,7 +99,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task GetOrganization_ReturnsOk_WhenOrganizationExists()
         {
-            // Setup 
+            // Arrange 
             var testId = 1;
 
             _mockService
@@ -131,7 +131,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task GetOrganization_ReturnsNotFound_WhenNoOrganizationExist()
         {
-            // Setup 
+            // Arrange 
             var testId = 99;
             _mockService
                 .Setup(service => service.ExistsAsync(testId))

--- a/src/UnitTests/ApplicationTracker.Tests/Controllers/SourcesControllerTests.cs
+++ b/src/UnitTests/ApplicationTracker.Tests/Controllers/SourcesControllerTests.cs
@@ -48,7 +48,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task GetSources_ReturnsOk_WhenSourcesExists()
         {
-            // Setup 
+            // Arrange 
             _mockService
                 .Setup(service => service.GetAllAsync())
                 .ReturnsAsync(_sources);
@@ -74,7 +74,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task GetSources_ReturnsNotFound_WhenNoSourcesExists()
         {
-            // Setup
+            // Arrange
             _mockService
                 .Setup(service => service.GetAllAsync())
                 .ReturnsAsync(new List<SourceDto>());
@@ -99,7 +99,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task GetSource_ReturnsOk_WhenEnvironmentExists()
         {
-            // Setup 
+            // Arrange 
             var testId = 1;
 
             _mockService
@@ -133,7 +133,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task GetSource_ReturnsNotFound_WhenNoSourceExist()
         {
-            // Setup 
+            // Arrange 
             var testId = 99;
             _mockService
                 .Setup(service => service.ExistsAsync(testId))

--- a/src/UnitTests/ApplicationTracker.Tests/Controllers/WorkEnvironmentsControllerTests.cs
+++ b/src/UnitTests/ApplicationTracker.Tests/Controllers/WorkEnvironmentsControllerTests.cs
@@ -48,7 +48,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task GetEnvironments_ReturnsOk_WhenEnvironmentsExist()
         {
-            // Setup 
+            // Arrange 
             _mockService
                 .Setup(service => service.GetAllAsync())
                 .ReturnsAsync(_workEnvironments);
@@ -74,7 +74,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task GetEnvironments_ReturnsNotFound_WhenNoEnvironmentsExist()
         {
-            // Setup
+            // Arrange
             _mockService
                 .Setup(service => service.GetAllAsync())
                 .ReturnsAsync(new List<WorkEnvironmentDto>());
@@ -99,7 +99,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task GetWorkEnvironment_ReturnsOk_WhenEnvironmentExists()
         {
-            // Setup
+            // Arrange
             var testId = 1;
 
             _mockService
@@ -131,7 +131,7 @@ namespace ApplicationTracker.Tests.Controllers
         [Test]
         public async Task GetWorkEnvironment_ReturnsNotFound_WhenEnvironmentDoesNotExist()
         {
-            // Setup 
+            // Arrange 
             var testId = 99;
             _mockService
                 .Setup(service => service.ExistsAsync(testId))


### PR DESCRIPTION
Adding AppEvent entity and enums for ContactMethod and EventType 
Added Migration EF Migration for the Entity 
Updated ApplicationDao to include property IsRejected (Any AppEvent of type Rejected)
Updated required GetAllAsync,, GetByIdAsync, and MapToDoa methods to handle AppEvent addition.
Added unit test for GetByIdAsync to test MapToDao functionality
